### PR TITLE
Fix mobile login redirect

### DIFF
--- a/pcwebapp/templates/header.html
+++ b/pcwebapp/templates/header.html
@@ -46,7 +46,7 @@
                       data-size="large"
                       data-userpic="false"
                       data-radius="5"
-                      data-auth-url="{% url 'telegram_login' %}"
+                      data-auth-url="{% url 'telegram_login' %}?next={{ request.get_full_path }}"
                       data-request-access="write"
                       data-lang="ru"
                     ></script>
@@ -416,7 +416,7 @@
   btnContainer.addEventListener('click', () => {
     // Здесь явно указываем ваш BOT_ID и origin
     const BOT_ID = '7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU';      // передайте через контекст шаблона
-    const origin = window.location.origin + '/pc/';       // например, https://example.com
+    const origin = window.location.origin;       // например, https://example.com
 
     const params = new URLSearchParams({
       bot_id: BOT_ID,

--- a/pcwebapp/views.py
+++ b/pcwebapp/views.py
@@ -4,6 +4,7 @@ import hmac
 import time
 from django.conf import settings
 from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.http import HttpResponseBadRequest
 from webapp.models import User  # ваша модель webapp.User
 from .decorators import webapp_login_required
@@ -100,6 +101,10 @@ def telegram_login(request):
         user.save()
 
     request.session['webapp_user_tgId'] = user.tgId
+
+    next_url = request.GET.get('next')
+    if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+        return redirect(next_url)
 
     return redirect('account')  # куда угодно внутри webapp
 


### PR DESCRIPTION
## Summary
- preserve current page on Telegram login
- redirect back to `next` URL after authentication

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687b94872310832d83b3309606da411b