### PR TITLE
Integrate bot login flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,79 +1,98 @@
 import os
 import django
-from aiogram import Bot, Dispatcher, executor, types
-from asgiref.sync import sync_to_async
-from aiogram.types import WebAppInfo, InlineKeyboardMarkup, InlineKeyboardButton
+import requests
+import telebot
+from telebot import types
 
-# --- Инициализация Django ---
+# --- Django initialization ---
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "legitcheck.settings")
 django.setup()
 
 from webapp.models import Verdict
 
 API_TOKEN = "7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU"
-bot = Bot(token=API_TOKEN, parse_mode=types.ParseMode.HTML)
-dp = Dispatcher(bot)
+SERVER_URL = "https://legitcheck.one"
+
+bot = telebot.TeleBot(API_TOKEN, parse_mode="HTML")
 
 
-# Синхронный доступ к одному Verdict по коду + первая фотография
-@sync_to_async
 def fetch_verdict_by_code(code):
+    """Return Verdict instance and first photo path for given code."""
     try:
-        v = Verdict.objects.prefetch_related('photos').get(code__iexact=code)
+        verdict = Verdict.objects.prefetch_related("photos").get(code__iexact=code)
     except Verdict.DoesNotExist:
         return None, None
 
-    first = v.photos.first()
+    first = verdict.photos.first()
     photo_path = first.image.path if first else None
-    return v, photo_path
+    return verdict, photo_path
 
 
-@dp.message_handler(commands=['start'])
-async def cmd_start(message: types.Message):
-    """
-    Обрабатывает deep link /start=<code>:
-    - если code передан, ищет Verdict по нему и присылает данные
-    - иначе просит запустить бота со ссылкой
-    """
-    args = message.get_args().strip()
+@bot.message_handler(commands=["start"])
+def handle_start(message: telebot.types.Message):
+    """Handle /start with either a verdict code or login token."""
+    parts = message.text.split(maxsplit=1)
+    args = parts[1].strip() if len(parts) > 1 else ""
+
     if not args:
-        await message.reply("❗️ Пожалуйста, запускайте бота по специальной ссылке вида `https://t.me/YourBot?start=<code>`.")
+        bot.reply_to(
+            message,
+            "❗️ Пожалуйста, запускайте бота по ссылке вида https://t.me/YourBot?start=<token>.",
+        )
+        return
+
+    if args.startswith("login_"):
+        token = args[len("login_"):]
+        payload = {
+            "token": token,
+            "user": {
+                "id": message.from_user.id,
+                "first_name": message.from_user.first_name or "",
+                "last_name": message.from_user.last_name or "",
+                "username": message.from_user.username or "",
+            },
+        }
+        try:
+            r = requests.post(f"{SERVER_URL}/pc/telegram/bot-login/", json=payload, timeout=5)
+            if r.ok:
+                bot.reply_to(message, "Вы успешно авторизованы на сайте.")
+            else:
+                bot.reply_to(message, f"Ошибка авторизации: {r.text}")
+        except Exception:
+            bot.reply_to(message, "Не удалось связаться с сервером.")
         return
 
     code = args
-    webapp_url = f"https://legitcheck.one/verdict?code={code}"
-    button = InlineKeyboardButton(
-        text="🔗 Открыть веб-приложение",
-        web_app=WebAppInfo(url=webapp_url)
-    )
-    markup = InlineKeyboardMarkup().add(button)
-    v, photo_path = await fetch_verdict_by_code(code)
-    if not v:
-        await message.reply(f"❌ Вердикт с кодом <b>{code}</b> не найден.")
+    verdict, photo_path = fetch_verdict_by_code(code)
+    if not verdict:
+        bot.reply_to(message, f"❌ Вердикт с кодом <b>{code}</b> не найден.")
         return
 
+    webapp_url = f"{SERVER_URL}/verdict?code={code}"
+    markup = types.InlineKeyboardMarkup()
+    markup.add(types.InlineKeyboardButton(text="🔗 Открыть веб-приложение", web_app=types.WebAppInfo(url=webapp_url)))
+
     caption = (
-        f"<b>Код:</b> {v.code}\n"
-        f"<b>Категория вещи:</b> {v.get_category_display()}\n"
-        f"<b>Бренд:</b> {v.brand}\n"
-        f"<b>Модель:</b> {v.item_model}\n"
-        f"<b>Статус проверки:</b> {v.get_status_display()}\n"
-        f"<b>Дата:</b> {v.created_at:%Y-%m-%d %H:%M}\n"
-        f"<b>Комментарий:</b> {v.comment}\n"
-        f"<b>Комментарий пользователя:</b> {v.comment_from_user}"
+        f"<b>Код:</b> {verdict.code}\n"
+        f"<b>Категория вещи:</b> {verdict.get_category_display()}\n"
+        f"<b>Бренд:</b> {verdict.brand}\n"
+        f"<b>Модель:</b> {verdict.item_model}\n"
+        f"<b>Статус проверки:</b> {verdict.get_status_display()}\n"
+        f"<b>Дата:</b> {verdict.created_at:%Y-%m-%d %H:%M}\n"
+        f"<b>Комментарий:</b> {verdict.comment}\n"
+        f"<b>Комментарий пользователя:</b> {verdict.comment_from_user}"
     )
 
     if photo_path and os.path.exists(photo_path):
-        photo = types.InputFile(photo_path)
-        await bot.send_photo(
-            chat_id=message.chat.id,
-            photo=photo,
-            caption=caption,
-            reply_markup=markup
-        )
+        with open(photo_path, "rb") as f:
+            bot.send_photo(message.chat.id, f, caption=caption, reply_markup=markup)
     else:
-        await message.answer(caption)
+        bot.send_message(message.chat.id, caption, reply_markup=markup)
 
 
-if __name__ == '__main__':
-    executor.start_polling(dp, skip_updates=True)
+def main():
+    bot.infinity_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rewrite Telegram bot to use `pyTelegramBotAPI`
- add support for `/start login_<token>` for PC login

## Testing
- `python manage.py check`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687c285686cc832da6bcc853f4787d90