### PR TITLE
Shorten Telegram login token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # legitcheck
+
+В проекте используется Telegram‑бот `@LegitLogisticsBot` для авторизации
+пользователей. Токены авторизации теперь короче (16 символов) и
+передаются боту через ссылку вида:
+
+```
+https://t.me/LegitLogisticsBot?start=login_<token>
+```
+
+`BOT_TOKEN` и `TELEGRAM_BOT_TOKEN` можно задать через одноимённые
+переменные окружения.

--- a/legitcheck/settings.py
+++ b/legitcheck/settings.py
@@ -22,7 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-%7t^@^hct!d*e2*-ss7((0wy#+5^ne^=oe)ku_cy4e(c35ta=b'
 
-TELEGRAM_BOT_TOKEN = '7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU'
+import os
+
+TELEGRAM_BOT_TOKEN = os.environ.get(
+    'TELEGRAM_BOT_TOKEN',
+    '7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU'
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/main.py
+++ b/main.py
@@ -33,7 +33,10 @@ except Exception:
 
 # --- Config ----------------------------------------------------------------
 
-BOT_TOKEN: str = "7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU"
+BOT_TOKEN: str = os.environ.get(
+    "BOT_TOKEN",
+    "7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU",
+)
 BACKEND_BASE_URL: str = "https://legitcheck.one/"
 BOT_BACKEND_SECRET: Optional[str] = os.environ.get("BOT_BACKEND_SECRET") or None
 
@@ -42,7 +45,7 @@ if not BACKEND_BASE_URL:
 
 
 TOKEN_PREFIX = "login_"
-TOKEN_RE = re.compile(rf"^{TOKEN_PREFIX}([a-f0-9]{{32,64}})$")  # hex 128–256 бит
+TOKEN_RE = re.compile(rf"^{TOKEN_PREFIX}([a-f0-9]{16})$")  # 16 hex chars token
 
 CONFIRM_ENDPOINT = f"{BACKEND_BASE_URL}/internal/telegram/confirm/"
 

--- a/pcwebapp/migrations/0001_initial.py
+++ b/pcwebapp/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='LoginToken',
             fields=[
-                ('token', models.CharField(max_length=64, primary_key=True, serialize=False)),
+                ('token', models.CharField(max_length=16, primary_key=True, serialize=False)),
                 ('session_key', models.CharField(db_index=True, max_length=40)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('expires_at', models.DateTimeField()),

--- a/pcwebapp/models.py
+++ b/pcwebapp/models.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from datetime import timedelta
 
 class LoginToken(models.Model):
-    token = models.CharField(max_length=64, primary_key=True)        # hex
+    token = models.CharField(max_length=16, primary_key=True)        # shorter hex token
     session_key = models.CharField(max_length=40, db_index=True)
     created_at = models.DateTimeField(auto_now_add=True)
     expires_at = models.DateTimeField()
@@ -13,7 +13,7 @@ class LoginToken(models.Model):
     @classmethod
     def create_for_session(cls, session_key, ttl_minutes=5):
         import secrets
-        raw = secrets.token_hex(32)  # 64 hex chars = 256 bits
+        raw = secrets.token_hex(8)  # 16 hex chars = 64 bits
         return cls.objects.create(
             token=raw,
             session_key=session_key,

--- a/pcwebapp/views.py
+++ b/pcwebapp/views.py
@@ -1,38 +1,25 @@
-from django.shortcuts import render, redirect
 import hashlib
 import hmac
-import time
 import json
-from django.conf import settings
-from django.utils.http import url_has_allowed_host_and_scheme
-from django.http import HttpResponseBadRequest, JsonResponse
-from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
-from webapp.models import User  # ваша модель webapp.User
-from django.contrib.sessions.backends.db import SessionStore
-import secrets
-from .decorators import webapp_login_required
-from django.shortcuts import redirect
-from django.views.decorators.csrf import csrf_exempt
-from django.utils.http import url_has_allowed_host_and_scheme
-
-from django.views.decorators.http import require_POST, require_GET
-from django.http import JsonResponse, HttpResponseBadRequest
-from django.utils import timezone
-from .models import LoginToken
-
-import time
-import hmac
-import hashlib
 import logging
+import time
 from urllib.parse import unquote
 
 from django.conf import settings
-from django.http import (
-    JsonResponse,
-    HttpResponseBadRequest,
-    HttpResponse
-)
+from django.contrib.sessions.backends.db import SessionStore
+from django.contrib.auth import login
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.shortcuts import render, redirect
+from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET, require_POST
+
+from webapp.models import User  # ваша модель webapp.User
+from .decorators import webapp_login_required
+from .models import LoginToken
+
+logger = logging.getLogger(__name__)
 
 TELEGRAM_LOGIN_MAX_AGE = 300  # секунд
 
@@ -93,8 +80,6 @@ def home_page(request):
     return render(request, 'pc/home_page.html')
 
 
-
-from .models import LoginToken
 
 @require_POST
 def telegram_request_login(request):

--- a/webapp/migrations/0011_logintoken.py
+++ b/webapp/migrations/0011_logintoken.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("token", models.CharField(max_length=32, unique=True)),
+                ("token", models.CharField(max_length=16, unique=True)),
                 ("session_key", models.CharField(blank=True, max_length=40, null=True)),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 ("used", models.BooleanField(default=False)),

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -140,7 +140,7 @@ class Payment(models.Model):
 
 class LoginToken(models.Model):
     """One-time tokens for login via Telegram bot."""
-    token = models.CharField(max_length=32, unique=True)
+    token = models.CharField(max_length=16, unique=True)
     session_key = models.CharField(max_length=40, blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     used = models.BooleanField(default=False)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,13 +2,17 @@ from django.shortcuts import render, redirect, get_object_or_404
 from telebot.util import parse_web_app_data
 from .models import User, Verdict, VerdictPhoto
 from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_protect
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.views.decorators.csrf import csrf_exempt
-from django.http import JsonResponse, HttpResponseBadRequest
+from django.http import JsonResponse
 
-TELEGRAM_BOT_TOKEN = "7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU"
+import os
+
+TELEGRAM_BOT_TOKEN = os.environ.get(
+    "TELEGRAM_BOT_TOKEN",
+    "7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU",
+)
 
 def init(request):
     # Точка входа: показываем кнопку Telegram WebApp


### PR DESCRIPTION
## Summary
- shorten login tokens to 16 hex characters
- read bot tokens from environment
- trim unused imports in Django views
- document Telegram bot login usage

## Testing
- `python -m compileall -q .`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687c2f471920832da17a33fce932473c