### PR TITLE
Add domain specific routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # legitcheck
+
+This project now serves two different Django apps depending on the request domain:
+
+- `webapp` is accessible via **https://legitcheck.one**
+- `pcwebapp` is accessible via **https://checkerlegit.com**
+
+The middleware `DomainRoutingMiddleware` chooses the proper URL configuration based on the host name.

--- a/legitcheck/host_routing_middleware.py
+++ b/legitcheck/host_routing_middleware.py
@@ -1,0 +1,12 @@
+class DomainRoutingMiddleware:
+    """Switch URL configuration based on the request host."""
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        host = request.get_host().split(':')[0].lower()
+        if host in ("checkerlegit.com", "www.checkerlegit.com"):
+            request.urlconf = "legitcheck.urls_pcwebapp"
+        else:
+            request.urlconf = "legitcheck.urls_webapp"
+        return self.get_response(request)

--- a/legitcheck/settings.py
+++ b/legitcheck/settings.py
@@ -27,7 +27,7 @@ TELEGRAM_BOT_TOKEN = '7620197633:AAHqBbPgVEtloxy6we7YyvMU7eWK9-hSyrU'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['89.169.2.234', 'legitcheck.one']
+ALLOWED_HOSTS = ['89.169.2.234', 'legitcheck.one', 'checkerlegit.com']
 
 SECURE_SSL_REDIRECT = True
 SESSION_COOKIE_SECURE = True
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'legitcheck.host_routing_middleware.DomainRoutingMiddleware',
     'django.middleware.common.CommonMiddleware',
     # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/legitcheck/urls_pcwebapp.py
+++ b/legitcheck/urls_pcwebapp.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('', include('pcwebapp.urls')),
+]

--- a/legitcheck/urls_webapp.py
+++ b/legitcheck/urls_webapp.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('', include('webapp.urls')),
+]

--- a/pcwebapp/templates/pc/verdict.html
+++ b/pcwebapp/templates/pc/verdict.html
@@ -155,7 +155,7 @@
                   </div>
                 </div>
                 <div class="_2-verdict__frame-134">
-                  <img class="_2-verdict__image" src="https://legitcheck.one/media/{{ first_photo.image }}" />
+                  <img class="_2-verdict__image" src="{{ first_photo.image.url }}" />
                   <div class="_2-verdict__image-16"></div>
                   <div class="_2-verdict__frame-1948754069">
                     <div class="_2-verdict__div10">{{ verdict.get_status_display }}</div>

--- a/webapp/templates/verdict.html
+++ b/webapp/templates/verdict.html
@@ -123,7 +123,7 @@
                 <div id="verdict-model" class="text-white text-lg font-semibold">{{ verdict.item_model }}</div>
               </div>
               <!-- Картинка: первая из загруженных -->
-              <img id="verdict-photo" src="https://legitcheck.one/media/{{ first_photo.image }}" alt="Sneaker" class="w-32 h-auto rounded-lg object-cover" />
+              <img id="verdict-photo" src="{{ first_photo.image.url }}" alt="Sneaker" class="w-32 h-auto rounded-lg object-cover" />
               <!-- Текстовые данные -->
             </div>
           </div>


### PR DESCRIPTION
## Summary
- serve `webapp` at `legitcheck.one` and `pcwebapp` at `checkerlegit.com`
- add new `DomainRoutingMiddleware`
- adjust ALLOWED_HOSTS and middleware settings
- fix verdict templates to use relative media URLs

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687d18c95b10832d85da624be0507a8c