### PR TITLE
feat: support device accounts in webapp init

### DIFF
--- a/webapp/templates/init.html
+++ b/webapp/templates/init.html
@@ -12,12 +12,10 @@
     Telegram.WebApp.ready();
     const initData = Telegram.WebApp.initData;
     if (initData) {
-      // генерируем URL по имени маршрута 'home'
-      const homeUrl = "{% url 'home' %}";
-      // редиректим на /home/?init_data=…
-      window.location.replace(homeUrl + "?init_data=" + encodeURIComponent(initData));
+      window.location.replace("?init_data=" + encodeURIComponent(initData));
     } else {
-      document.body.innerHTML = '<p>Не удалось получить initData</p>';
+      // если Telegram недоступен, инициируем создание аккаунта устройства
+      window.location.replace("?device=1");
     }
   </script>
 </body>

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -3,7 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.init, name='init'),  # пример маршрута
-    path('home/', views.index, name='home'),  # пример маршрута
+    path('home/', views.init, name='home'),  # главная страница после инициализации
     path('about/', views.about, name='about'),  # ещё один маршрут
     path('account/', views.cab, name="lk"),
     path('verdicts/', views.verdicts, name="verdicts"),


### PR DESCRIPTION
## Summary
- allow `init` view to create or reuse device accounts when Telegram data is absent
- redirect webapp initialization script based on presence of Telegram data
- map `home/` URL to the new `init` handler

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'unfold.admin')*


------
https://chatgpt.com/codex/tasks/task_e_688f3810fadc832da7c9642f898e7937